### PR TITLE
Run using `node20` (not `node16`)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ outputs:
     description: Whether the cache was successfuly restored
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/main/index.js'
   post: 'dist/post/index.js'
   post-if: 'success()'


### PR DESCRIPTION
The same as upstream PR:
- https://github.com/pass-culture-github-actions/gcs-cache/pull/1

---

## What

Let's start [`runs.using: 'node20'`](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions) in this action.

## Why

This action has started failing for us this week, where we're getting errors such as:

```javascript
TypeError: Cannot read properties of null (reading 'length')
      at getStateLength (/home/runner/_work/_actions/pass-culture-github-actions/gcs-cache/a15865adf837a570fa52671cab4d83baad2aceab/dist/main/index.js:198:27987)
      at shift (/home/runner/_work/_actions/pass-culture-github-actions/gcs-cache/a15865adf837a570fa52671cab4d83baad2aceab/dist/main/index.js:198:27851)
      at Duplexify._forward (/home/runner/_work/_actions/pass-culture-github-actions/gcs-cache/a15865adf837a570fa52671cab4d83baad2aceab/dist/main/index.js:177:11566)
      at PassThrough.onreadable (/home/runner/_work/_actions/pass-culture-github-actions/gcs-cache/a15865adf837a570fa52671cab4d83baad2aceab/dist/main/index.js:177:10980)
      at PassThrough.emit (node:events:519:28)
      at emitReadable_ (node:internal/streams/readable:832:12)
      at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
  Node.js v20.13.1
```

We also get this warning:
>The following actions uses Node.js version which is deprecated and will be forced to run on node20: `pass-culture-github-actions/gcs-cache@v1.0.0` For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

...where they say:
>Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 3rd of June.